### PR TITLE
updating environment.yml

### DIFF
--- a/.github/ci_support/environment.yml
+++ b/.github/ci_support/environment.yml
@@ -1,4 +1,4 @@
 channels:
   - conda-forge
 dependencies:
-  - jupyter-book
+  - jupyter-book=0.10.2

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 channels:
 - conda-forge
+- conda-forge/label/broken
 dependencies:
 - python=3.8
 - pyiron_atomistics=0.2.10


### PR DESCRIPTION
Since the `damask=3.0.0` is available only from broken labels of conda-forge channel, this channel is added to environment. Otherwise the binder link does not work anymore.